### PR TITLE
fix: make LEETCODE_COOKIE optional for public API endpoints

### DIFF
--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -444,7 +444,7 @@ mod tests {
         // Cookie header should not be present when env var is empty
         assert!(!headers.contains_key("Cookie"));
 
-        // Test 2: With cookie
+        // Test 2: With valid cookie
         unsafe {
             std::env::set_var("LEETCODE_COOKIE", "test_cookie_value");
         }
@@ -457,6 +457,15 @@ mod tests {
             headers.get("Cookie").unwrap().to_str().unwrap(),
             "test_cookie_value"
         );
+
+        // Test 3: With invalid cookie characters (should not panic, just skip cookie)
+        unsafe {
+            std::env::set_var("LEETCODE_COOKIE", "invalid\n\rcookie");
+        }
+
+        let headers = build_headers();
+        // Cookie should not be present when it contains invalid characters
+        assert!(!headers.contains_key("Cookie"));
 
         // Restore original cookie
         unsafe {


### PR DESCRIPTION
Problem download now works without requiring a LeetCode session cookie:
- Cookie is only required for authenticated endpoints (submissions, etc.)
- Public problem list and details APIs work without authentication
- Added build_headers() function to handle optional cookie
- Simplified headers for better compatibility
- Added HTTP status check for better error handling

Changes:
- Made LEETCODE_COOKIE optional in get_problems()
- Updated get_problem() to use shared build_headers()
- Added proper HTTP status code checking
- Added test_build_headers() to verify cookie handling
- Combined header tests to avoid race conditions

Tested: Successfully downloaded problems #4 and #6 without cookie