### PR TITLE
refactor: CLI with clap arguments, retry logic, and better error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,285 @@
+# LeetCode Rust - Project Guide for AI Agents
+
+## Project Overview
+
+This is a LeetCode solution development toolkit written in Rust. It provides:
+
+1. **Interactive CLI tool** (`cargo run`) to fetch LeetCode problems and generate Rust solution templates
+2. **Problem organization** with separate directories for in-progress (`problem/`) and completed (`solution/`) solutions
+3. **Utility modules** for common LeetCode data structures (ListNode, TreeNode, Point)
+4. **Automated testing** infrastructure using cargo-nextest and coverage reporting
+
+## Technology Stack
+
+- **Language**: Rust (Edition 2024)
+- **Toolchain**: Nightly (`nightly-2025-12-01`)
+- **Task Runner**: cargo-make
+- **Test Runner**: cargo-nextest
+- **Coverage**: cargo-llvm-cov
+- **HTTP Client**: reqwest (blocking), surf (async)
+- **Serialization**: serde, serde_json
+
+## Project Structure
+
+```
+├── Cargo.toml              # Rust package manifest
+├── rust-toolchain          # Nightly toolchain specification
+├── rustfmt.toml           # Code formatting configuration
+├── Makefile.toml          # cargo-make task definitions
+├── template.rs            # Problem template file used by generator
+├── .env                   # Environment variables (LEETCODE_COOKIE)
+├── .typos.toml           # Typo checker configuration
+├── dev                   # Setup script for cargo-make
+└── src/
+    ├── main.rs           # CLI entry point - problem fetcher/generator
+    ├── lib.rs            # Library root
+    ├── fetcher.rs        # LeetCode API client (GraphQL + REST)
+    ├── problem/          # In-progress problem solutions
+    │   ├── mod.rs        # Module declarations for all problems
+    │   └── p{xxxx}_{title}.rs  # Individual problem files
+    ├── solution/         # Completed solutions (optional)
+    │   └── mod.rs        # Module declarations (referenced but empty)
+    └── util/             # Helper utilities
+        ├── mod.rs
+        ├── linked_list.rs    # ListNode and macros (linked!, list!)
+        ├── tree.rs           # TreeNode and macros (tree!)
+        ├── point.rs          # Point struct
+        └── vec_string.rs     # Vec<String> helpers
+```
+
+## Build and Development Commands
+
+### Prerequisites
+
+1. Set `LEETCODE_COOKIE` in `.env` file or environment variable (LeetCode session cookie for API access)
+2. Run `./dev` to install cargo-make (or install manually: `cargo install cargo-make`)
+
+### CLI Usage
+
+The CLI now uses subcommands with proper argument parsing (via `clap`):
+
+```bash
+# Generate template for a specific problem
+cargo run -- get <problem_id>
+leetcode-rust get <problem_id>    # if installed
+
+# Generate a random problem template
+cargo run -- random
+leetcode-rust random
+
+# Initialize ALL problems (warning: fetches all LeetCode problems!)
+cargo run -- all
+leetcode-rust all
+
+# Move a problem from problem/ to solution/ when completed
+cargo run -- solve <problem_id>
+leetcode-rust solve <problem_id>
+
+# List all initialized problems
+cargo run -- list
+leetcode-rust list
+
+# Get help
+cargo run -- --help
+cargo run -- get --help
+```
+
+### Legacy Interactive Mode (OLD - No longer supported)
+
+The old interactive mode has been replaced with proper CLI arguments for better UX and scripting support.
+
+### Test Commands
+
+```bash
+# Test a specific solution
+cargo test test_{problem_id}
+
+# Run all tests
+cargo nextest run --workspace --all-features --all-targets
+```
+
+### cargo-make Tasks (via `./dev` or `cargo make`)
+
+| Task | Description |
+|------|-------------|
+| `check` | Run all checks (fmt, deps, clippy, machete, test, typos) |
+| `test` | Run unit tests with cargo-nextest |
+| `test-cov` | Run tests and generate HTML coverage report |
+| `check-fmt` | Check code formatting |
+| `check-clippy` | Run clippy with warnings as errors |
+| `check-typos` | Run typo checker |
+| `check-machete` | Check for unused dependencies |
+| `check-dep-sort` | Check dependency sorting in Cargo.toml |
+| `clean` | Run cargo clean |
+
+## Code Style Guidelines
+
+### Formatting (rustfmt.toml)
+
+- **Edition**: 2021
+- **Style Edition**: 2024
+- **Comment Width**: 120 characters
+- **Tab Spaces**: 4
+- **Import Organization**: Group by `StdExternalCrate`
+- **Imports Granularity**: Crate-level
+- **Format doc comments**: Enabled
+- **Normalize comments**: Enabled
+- **Wrap comments**: Enabled
+
+### Problem File Structure
+
+Each problem file follows this template:
+
+```rust
+/**
+ * [{problem_id}] {Problem Title}
+ *
+ * {Problem description}
+ */
+pub struct Solution {}
+
+// problem: https://leetcode.com/problems/{title-slug}/
+// discuss: https://leetcode.com/problems/{title-slug}/discuss/...
+
+// submission codes start here
+
+impl Solution {
+    pub fn solution_method(...) -> ... {
+        // Implementation
+    }
+}
+
+// submission codes end
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_{problem_id}() {
+        // Test cases
+    }
+}
+```
+
+### Naming Conventions
+
+- Problem files: `p{xxxx}_{snake_case_title}.rs` (e.g., `p0001_two_sum.rs`)
+- Solution files: `s{xxxx}_{snake_case_title}.rs` (e.g., `s0001_two_sum.rs`)
+- Test functions: `test_{problem_id}` (e.g., `test_1`)
+- Module declarations in `problem/mod.rs`: `pub mod p{xxxx}_{title};`
+
+## Testing Instructions
+
+### Running Tests
+
+```bash
+# All tests
+cargo nextest run
+
+# Specific problem test
+cargo test test_1  # for problem #1
+
+# With coverage
+cargo llvm-cov nextest --workspace --all-features --all-targets --html
+```
+
+### Test Structure
+
+Tests are co-located in each problem file using `#[cfg(test)]` modules. The project uses:
+
+- **Standard Rust testing** with `#[test]` attribute
+- **cargo-nextest** as the test runner in CI (faster, better output)
+- **Test utilities** from `util/` module for creating test data
+
+### Utility Macros for Testing
+
+```rust
+// Linked lists
+linked![1, 2, 3]  // Create linked list from values
+list![1, 2, 3]    // Alternative syntax
+
+// Trees
+tree![1, 2, 3]    // Create binary tree from level-order values
+```
+
+## CI/CD and Automation
+
+### GitHub Actions Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `check.yml` | PR, push to main | fmt, clippy, typos checks |
+| `test.yml` | PR, push to main | Test on Ubuntu/macOS/Windows + coverage |
+| `safety.yml` | Scheduled | Security auditing |
+| `scheduled.yml` | Scheduled | Dependency updates |
+| `scorecards.yml` | PR, push | OpenSSF Scorecard |
+| `dependency-review.yml` | PR | Dependency security review |
+
+### Security Hardening
+
+- Uses `step-security/harden-runner` in CI workflows
+- Codecov integration for coverage reporting
+- OpenSSF Scorecard for security metrics
+
+## Key Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `clap` | CLI argument parsing with derive macros |
+| `reqwest` | HTTP client for LeetCode API |
+| `serde` / `serde_json` | JSON serialization |
+| `regex` | Text processing in template generation |
+| `dotenv` | Environment variable loading |
+| `futures` | Async runtime for bulk problem fetching |
+| `rand` | Random problem selection |
+| `thiserror` | Structured error handling |
+| `indicatif` | Progress bars for long operations |
+| `tokio` | Async runtime for retry delays |
+
+## Error Handling
+
+The CLI uses structured error handling with `thiserror`:
+
+- **User-friendly messages**: No more panics - all errors display helpful messages
+- **Retry logic**: Network requests automatically retry with exponential backoff (3 retries)
+- **Specific error types**: `ProblemNotFound`, `NoRustVersion`, `AlreadyInitialized`, etc.
+
+Example error output:
+```
+❌ Error: Problem #99999 not found (may be paid-only or doesn't exist)
+```
+
+## Development Notes
+
+### Adding a New Problem
+
+1. Run `cargo run -- get {problem_id}` to fetch and generate template
+2. Implement solution in the generated file
+3. Add test cases in the `#[cfg(test)]` module
+4. Run `cargo test test_{problem_id}` to verify
+5. Optionally move to solution/: `cargo run -- solve {problem_id}`
+
+### Working with LeetCode API
+
+The fetcher (`src/fetcher.rs`) uses:
+- **GraphQL endpoint** (`https://leetcode.com/graphql`) for problem details
+- **REST API** (`https://leetcode.com/api/problems/algorithms/`) for problem list
+- Requires `LEETCODE_COOKIE` environment variable (LeetCode session cookie)
+
+### Custom Data Structures
+
+The project provides Rust implementations of common LeetCode structures:
+
+- **`ListNode`** - Singly linked list with `val: i32` and `next: Option<Box<ListNode>>`
+- **`TreeNode`** - Binary tree with `Rc<RefCell<TreeNode>>` for shared ownership
+- **`Point`** - 2D point structure
+
+These are automatically imported in generated templates when needed based on return types.
+
+## Important Files for Agents
+
+- **Template**: `template.rs` - Used to generate new problem files
+- **Module Registry**: `src/problem/mod.rs` - Add `pub mod` declarations here
+- **Formatting**: `rustfmt.toml` - Run `cargo fmt --all` before committing
+- **Tasks**: `Makefile.toml` - Use `./dev <task>` for development tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +395,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +456,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -501,6 +610,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -803,6 +918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hkdf"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1108,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1140,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isahc"
@@ -1058,8 +1198,10 @@ dependencies = [
 name = "leetcode-rust"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "dotenv",
  "futures",
+ "indicatif",
  "rand 0.9.2",
  "regex",
  "reqwest",
@@ -1068,6 +1210,8 @@ dependencies = [
  "serde_json",
  "surf",
  "tempfile",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1204,6 +1348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1367,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -1353,6 +1509,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -1866,6 +2028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "universal-hash"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2364,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "value-bag"
@@ -2328,6 +2508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,7 +2584,25 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2408,17 +2622,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2435,9 +2650,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2453,9 +2668,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2471,9 +2686,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2489,9 +2710,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2507,9 +2728,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2525,9 +2746,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2543,9 +2764,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["ben1009"]
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5", features = ["derive"] }
 dotenv = "0.15.0"
 futures = { version = "0.3.30", features = ["thread-pool"] }
+indicatif = "0.17"
 rand = "0.9.2"
 regex = "1.5.5"
 reqwest = { version = "0.12", features = [
@@ -20,6 +22,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 surf = "2.3.2"
 tempfile = "3.9.0"
+thiserror = "1.0"
+tokio = { version = "1", features = ["time"] }
 
 [lib]
 doctest = false

--- a/README.md
+++ b/README.md
@@ -5,12 +5,50 @@
 
 Set `LEETCODE_COOKIE` in `.env` file or environment variable first.
 
-Run `cargo run {id}` to initialize the template submission file of "question #id".
+## CLI Usage
 
-Run `cargo test test_{id}` to test the solution for "question #id".
+The CLI uses subcommands for better UX:
 
-## Usage
+```bash
+# Get a specific problem by ID
+cargo run -- get <id>
 
-- Remove all the solution .rs
-- Clean lib.rs file
-- Start your leetcode journey in rust by typing `cargo run {question_id}`
+# Get a random problem
+cargo run -- random
+
+# Initialize ALL problems (warning: fetches all problems!)
+cargo run -- all
+
+# Move a problem from problem/ to solution/
+cargo run -- solve <id>
+
+# List all initialized problems
+cargo run -- list
+
+# Get help
+cargo run -- --help
+```
+
+## Testing
+
+```bash
+# Test a specific solution
+cargo test test_<id>
+
+# Run all tests
+cargo nextest run
+```
+
+## Features
+
+- ✅ **User-friendly CLI** with subcommands and help messages
+- ✅ **Auto-retry** with exponential backoff for network requests
+- ✅ **Progress indicators** for long-running operations
+- ✅ **Structured error handling** - no more panics!
+
+## Quick Start
+
+1. Set `LEETCODE_COOKIE` in `.env` file
+2. Run `cargo run -- get 1` to fetch problem #1
+3. Implement your solution in the generated file
+4. Run `cargo test test_1` to verify

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,116 @@
+//! Error types for leetcode-rust CLI
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Result type alias with LeetCodeError
+pub type Result<T> = std::result::Result<T, LeetCodeError>;
+
+/// Main error type for LeetCode CLI operations
+#[derive(Error, Debug)]
+pub enum LeetCodeError {
+    /// IO operation failed
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// HTTP request failed
+    #[error("HTTP request failed: {0}")]
+    Http(String),
+
+    /// Failed to parse JSON response
+    #[error("JSON parsing error: {0}")]
+    JsonParse(#[from] serde_json::Error),
+
+    /// Problem not found
+    #[error("Problem #{0} not found (may be paid-only or doesn't exist)")]
+    ProblemNotFound(u32),
+
+    /// No Rust version available for problem
+    #[error("Problem #{0} has no Rust version available")]
+    NoRustVersion(u32),
+
+    /// Problem already initialized
+    #[error("Problem #{0} has already been initialized in problem/")]
+    AlreadyInitialized(u32),
+
+    /// Solution already exists
+    #[error("Solution for problem #{0} already exists in solution/")]
+    SolutionExists(u32),
+
+    /// Problem file doesn't exist for solving
+    #[error("Problem file for #{0} doesn't exist in problem/")]
+    ProblemNotExist(u32),
+
+    /// Environment variable not set
+    #[allow(dead_code)]
+    #[error("Environment variable {0} not set")]
+    EnvVar(String),
+
+    /// Failed to build HTTP client
+    #[error("Failed to build HTTP client: {0}")]
+    HttpClientBuild(String),
+
+    /// Network error with retry exhaustion
+    #[error("Network error after {retries} retries: {message}")]
+    NetworkRetryExhausted { retries: u32, message: String },
+
+    /// Invalid input
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    /// Template file error
+    #[error("Template file error: {0}")]
+    Template(String),
+
+    /// Regex error
+    #[error("Regex error: {0}")]
+    Regex(#[from] regex::Error),
+
+    /// File operation error with path
+    #[error("Failed to {operation} file at {path}: {source}")]
+    FileOperation {
+        operation: String,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Async runtime error
+    #[error("Async runtime error: {0}")]
+    AsyncRuntime(String),
+
+    /// Missing problem title slug
+    #[error("Problem #{0} has no title slug")]
+    MissingTitleSlug(u32),
+
+    /// Missing metadata
+    #[error("Failed to parse metadata: {0}")]
+    MetadataParse(String),
+
+    /// Missing code definition
+    #[error("Failed to parse code definition: {0}")]
+    CodeDefinitionParse(String),
+}
+
+impl LeetCodeError {
+    /// Create a file operation error
+    pub fn file_operation(
+        operation: &str,
+        path: impl Into<PathBuf>,
+        source: std::io::Error,
+    ) -> Self {
+        Self::FileOperation {
+            operation: operation.to_string(),
+            path: path.into(),
+            source,
+        }
+    }
+
+    /// Create a network retry exhausted error
+    pub fn retry_exhausted(retries: u32, message: impl Into<String>) -> Self {
+        Self::NetworkRetryExhausted {
+            retries,
+            message: message.into(),
+        }
+    }
+}

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -1,9 +1,13 @@
-extern crate reqwest;
-extern crate serde_json;
+//! LeetCode API client with retry logic and user-friendly error handling
 
-use std::fmt::{Display, Error, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    time::Duration,
+};
 
 use serde_json::Value;
+
+use crate::error::{LeetCodeError, Result};
 
 const PROBLEMS_URL: &str = "https://leetcode.com/api/problems/algorithms/";
 const GRAPHQL_URL: &str = "https://leetcode.com/graphql";
@@ -19,126 +23,187 @@ query questionData($titleSlug: String!) {
 }"#;
 const QUESTION_QUERY_OPERATION: &str = "questionData";
 
-pub fn get_problem(frontend_question_id: u32) -> Option<Problem> {
-    let problems = match get_problems() {
-        Some(p) => p,
-        None => {
-            println!("Failed to fetch problems list");
-            return None;
-        }
-    };
-    for problem in problems.stat_status_pairs.iter() {
-        if problem.stat.frontend_question_id == frontend_question_id {
-            if problem.paid_only {
-                return None;
+/// Maximum number of retries for network requests
+const MAX_RETRIES: u32 = 3;
+/// Initial retry delay in milliseconds
+const INITIAL_RETRY_DELAY_MS: u64 = 500;
+
+/// Execute an operation with exponential backoff retry
+async fn with_retry<F, Fut, T>(operation: F, operation_name: &str) -> Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut delay = INITIAL_RETRY_DELAY_MS;
+
+    for attempt in 1..=MAX_RETRIES {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) if attempt < MAX_RETRIES => {
+                eprintln!(
+                    "⚠️  {} failed (attempt {}/{}): {}. Retrying in {}ms...",
+                    operation_name, attempt, MAX_RETRIES, e, delay
+                );
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                delay *= 2; // Exponential backoff
             }
-            println!("getting problem ...");
-            let headers = build_headers();
-            let client = reqwest::blocking::Client::new();
-            let slug = match problem.stat.question_title_slug.as_ref() {
-                Some(s) => s,
-                None => {
-                    println!("Problem {} has no title slug", frontend_question_id);
-                    return None;
-                }
-            };
-            let send_res = client
-                .post(GRAPHQL_URL)
-                .headers(headers)
-                .json(&Query::question_query(slug))
-                .send();
-            let resp: RawProblem = match send_res {
-                Ok(r) => match r.json() {
-                    Ok(json) => json,
-                    Err(e) => {
-                        println!("Failed to parse problem response JSON: {}", e);
-                        return None;
-                    }
-                },
-                Err(e) => {
-                    println!("HTTP request failed: {}", e);
-                    return None;
-                }
-            };
-
-            let code_definition: Vec<CodeDefinition> =
-                match serde_json::from_str(&resp.data.question.code_definition) {
-                    Ok(cd) => cd,
-                    Err(e) => {
-                        println!("Failed to parse code definition: {}", e);
-                        return None;
-                    }
-                };
-
-            let return_type = match serde_json::from_str::<Value>(&resp.data.question.meta_data) {
-                Ok(v) => v["return"]["type"].to_string().replace('"', ""),
-                Err(e) => {
-                    println!("Failed to parse meta_data: {}", e);
-                    return None;
-                }
-            };
-
-            return Some(Problem {
-                title: problem.stat.question_title.clone().unwrap_or_default(),
-                title_slug: problem.stat.question_title_slug.clone().unwrap_or_default(),
-                code_definition,
-                content: resp.data.question.content,
-                sample_test_case: resp.data.question.sample_test_case,
-                difficulty: problem.difficulty.to_string(),
-                question_id: problem.stat.frontend_question_id,
-                return_type,
-            });
+            Err(e) => {
+                return Err(LeetCodeError::retry_exhausted(MAX_RETRIES, e.to_string()));
+            }
         }
     }
-    None
+
+    unreachable!()
 }
 
-pub async fn get_problem_async(problem_stat: StatWithStatus) -> Option<Problem> {
+/// Execute a blocking operation with exponential backoff retry
+fn with_retry_blocking<F, T>(operation: F, operation_name: &str) -> Result<T>
+where
+    F: Fn() -> Result<T>,
+{
+    let mut delay = INITIAL_RETRY_DELAY_MS;
+
+    for attempt in 1..=MAX_RETRIES {
+        match operation() {
+            Ok(result) => return Ok(result),
+            Err(e) if attempt < MAX_RETRIES => {
+                eprintln!(
+                    "⚠️  {} failed (attempt {}/{}): {}. Retrying in {}ms...",
+                    operation_name, attempt, MAX_RETRIES, e, delay
+                );
+                std::thread::sleep(Duration::from_millis(delay));
+                delay *= 2; // Exponential backoff
+            }
+            Err(e) => {
+                return Err(LeetCodeError::retry_exhausted(MAX_RETRIES, e.to_string()));
+            }
+        }
+    }
+
+    unreachable!()
+}
+
+/// Fetch a single problem by its frontend ID
+pub fn get_problem(frontend_question_id: u32) -> Result<Problem> {
+    eprintln!(
+        "📡 Fetching problem list to find problem #{}...",
+        frontend_question_id
+    );
+    let problems = get_problems()?;
+
+    let problem_stat = problems
+        .stat_status_pairs
+        .iter()
+        .find(|p| p.stat.frontend_question_id == frontend_question_id)
+        .ok_or(LeetCodeError::ProblemNotFound(frontend_question_id))?;
+
     if problem_stat.paid_only {
-        println!(
-            "Problem {} is paid-only",
-            &problem_stat.stat.frontend_question_id
-        );
-        return None;
+        return Err(LeetCodeError::ProblemNotFound(frontend_question_id));
     }
-    let resp = surf::post(GRAPHQL_URL).body_json(&Query::question_query(
-        problem_stat.stat.question_title_slug.as_ref().unwrap(),
-    ));
-    if resp.is_err() {
-        println!(
-            "Problem {} not initialized due to some error",
-            &problem_stat.stat.frontend_question_id
-        );
-        return None;
-    }
-    let recv = resp.unwrap().recv_json().await;
-    if recv.is_err() {
-        println!(
-            "Problem {} not initialized due to some error",
-            &problem_stat.stat.frontend_question_id
-        );
-        return None;
-    }
-    let resp: RawProblem = recv.unwrap();
+
+    let slug = problem_stat
+        .stat
+        .question_title_slug
+        .as_ref()
+        .ok_or(LeetCodeError::MissingTitleSlug(frontend_question_id))?;
+
+    eprintln!("📡 Fetching problem details for '{}'...", slug);
+
+    with_retry_blocking(
+        || {
+            fetch_problem_detail(
+                &problem_stat.stat,
+                slug,
+                &problem_stat.difficulty.to_string(),
+            )
+        },
+        "Fetch problem detail",
+    )
+}
+
+fn fetch_problem_detail(stat: &Stat, slug: &str, difficulty: &str) -> Result<Problem> {
+    let headers = build_headers();
+    let client = reqwest::blocking::Client::new();
+
+    let response = client
+        .post(GRAPHQL_URL)
+        .headers(headers)
+        .json(&Query::question_query(slug))
+        .send()
+        .map_err(|e| LeetCodeError::Http(e.to_string()))?;
+
+    let raw_problem: RawProblem = response
+        .json()
+        .map_err(|e| LeetCodeError::Http(format!("Failed to parse response: {}", e)))?;
 
     let code_definition: Vec<CodeDefinition> =
-        match serde_json::from_str(&resp.data.question.code_definition) {
-            Ok(cd) => cd,
-            Err(e) => {
-                println!("Failed to parse code definition: {}", e);
-                return None;
-            }
-        };
+        serde_json::from_str(&raw_problem.data.question.code_definition)
+            .map_err(|e| LeetCodeError::CodeDefinitionParse(e.to_string()))?;
 
-    let return_type = match serde_json::from_str::<Value>(&resp.data.question.meta_data) {
+    let return_type = match serde_json::from_str::<Value>(&raw_problem.data.question.meta_data) {
         Ok(v) => v["return"]["type"].to_string().replace('"', ""),
-        Err(e) => {
-            println!("Failed to parse meta_data: {}", e);
-            return None;
-        }
+        Err(e) => return Err(LeetCodeError::MetadataParse(e.to_string())),
     };
 
-    Some(Problem {
+    Ok(Problem {
+        title: stat.question_title.clone().unwrap_or_default(),
+        title_slug: stat.question_title_slug.clone().unwrap_or_default(),
+        code_definition,
+        content: raw_problem.data.question.content,
+        sample_test_case: raw_problem.data.question.sample_test_case,
+        difficulty: difficulty.to_string(),
+        question_id: stat.frontend_question_id,
+        return_type,
+    })
+}
+
+/// Fetch problem asynchronously with retry logic
+pub async fn get_problem_async(problem_stat: StatWithStatus) -> Result<Problem> {
+    if problem_stat.paid_only {
+        return Err(LeetCodeError::ProblemNotFound(
+            problem_stat.stat.frontend_question_id,
+        ));
+    }
+
+    let slug =
+        problem_stat
+            .stat
+            .question_title_slug
+            .as_ref()
+            .ok_or(LeetCodeError::MissingTitleSlug(
+                problem_stat.stat.frontend_question_id,
+            ))?;
+
+    with_retry(
+        || fetch_problem_detail_async(slug, &problem_stat),
+        &format!(
+            "Fetch problem #{} async",
+            problem_stat.stat.frontend_question_id
+        ),
+    )
+    .await
+}
+
+async fn fetch_problem_detail_async(slug: &str, problem_stat: &StatWithStatus) -> Result<Problem> {
+    let resp = surf::post(GRAPHQL_URL)
+        .body_json(&Query::question_query(slug))
+        .map_err(|e| LeetCodeError::Http(e.to_string()))?;
+
+    let raw_problem: RawProblem = resp
+        .recv_json()
+        .await
+        .map_err(|e| LeetCodeError::Http(format!("Failed to receive JSON: {}", e)))?;
+
+    let code_definition: Vec<CodeDefinition> =
+        serde_json::from_str(&raw_problem.data.question.code_definition)
+            .map_err(|e| LeetCodeError::CodeDefinitionParse(e.to_string()))?;
+
+    let return_type = match serde_json::from_str::<Value>(&raw_problem.data.question.meta_data) {
+        Ok(v) => v["return"]["type"].to_string().replace('"', ""),
+        Err(e) => return Err(LeetCodeError::MetadataParse(e.to_string())),
+    };
+
+    Ok(Problem {
         title: problem_stat.stat.question_title.clone().unwrap_or_default(),
         title_slug: problem_stat
             .stat
@@ -146,8 +211,8 @@ pub async fn get_problem_async(problem_stat: StatWithStatus) -> Option<Problem> 
             .clone()
             .unwrap_or_default(),
         code_definition,
-        content: resp.data.question.content,
-        sample_test_case: resp.data.question.sample_test_case,
+        content: raw_problem.data.question.content,
+        sample_test_case: raw_problem.data.question.sample_test_case,
         difficulty: problem_stat.difficulty.to_string(),
         question_id: problem_stat.stat.frontend_question_id,
         return_type,
@@ -155,7 +220,6 @@ pub async fn get_problem_async(problem_stat: StatWithStatus) -> Option<Problem> 
 }
 
 /// Build HTTP headers for LeetCode API requests
-/// Cookie is optional - only needed for authenticated requests
 fn build_headers() -> reqwest::header::HeaderMap {
     let mut h = reqwest::header::HeaderMap::new();
     h.insert(
@@ -165,7 +229,8 @@ fn build_headers() -> reqwest::header::HeaderMap {
     h.insert(
         "User-Agent",
         reqwest::header::HeaderValue::from_static(
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+             (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
         ),
     );
     h.insert(
@@ -188,41 +253,39 @@ fn build_headers() -> reqwest::header::HeaderMap {
     h
 }
 
-pub fn get_problems() -> Option<Problems> {
-    println!("getting all problems ...");
+/// Fetch all problems list
+pub fn get_problems() -> Result<Problems> {
+    eprintln!("📡 Fetching problem list from LeetCode...");
 
-    let headers = build_headers();
-    let client = match reqwest::blocking::Client::builder().gzip(true).build() {
-        Ok(c) => c,
-        Err(e) => {
-            println!("Failed to build HTTP client: {}", e);
-            return None;
-        }
-    };
-    let get = client.get(PROBLEMS_URL).headers(headers);
-    let response = match get.send() {
-        Ok(r) => r,
-        Err(e) => {
-            println!("Failed to fetch problems URL: {}", e);
-            return None;
-        }
-    };
-    let status = response.status();
-    println!("Response status: {}", status);
-    if !status.is_success() {
-        println!("Failed to fetch problems: HTTP {}", status);
-        return None;
-    }
-    match response.json::<Problems>() {
-        Ok(p) => Some(p),
-        Err(e) => {
-            println!("Failed to decode problems JSON: {}", e);
-            None
-        }
-    }
+    with_retry_blocking(
+        || {
+            let headers = build_headers();
+            let client = reqwest::blocking::Client::builder()
+                .gzip(true)
+                .build()
+                .map_err(|e| LeetCodeError::HttpClientBuild(e.to_string()))?;
+
+            let response = client
+                .get(PROBLEMS_URL)
+                .headers(headers)
+                .send()
+                .map_err(|e| LeetCodeError::Http(e.to_string()))?;
+
+            let status = response.status();
+            if !status.is_success() {
+                return Err(LeetCodeError::Http(format!("HTTP {}", status)));
+            }
+
+            response
+                .json::<Problems>()
+                .map_err(|e| LeetCodeError::Http(format!("Failed to decode JSON: {}", e)))
+        },
+        "Fetch problems list",
+    )
 }
 
-#[derive(Serialize, Deserialize)]
+/// Problem data structure
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Problem {
     pub title: String,
     pub title_slug: String,
@@ -236,7 +299,8 @@ pub struct Problem {
     pub return_type: String,
 }
 
-#[derive(Serialize, Deserialize)]
+/// Code definition for a specific language
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CodeDefinition {
     pub value: String,
     pub text: String,
@@ -244,6 +308,7 @@ pub struct CodeDefinition {
     pub default_code: String,
 }
 
+/// GraphQL query structure
 #[derive(Debug, Serialize, Deserialize)]
 struct Query {
     #[serde(rename = "operationName")]
@@ -262,6 +327,7 @@ impl Query {
     }
 }
 
+/// Raw problem response from GraphQL
 #[derive(Debug, Serialize, Deserialize)]
 struct RawProblem {
     data: Data,
@@ -284,51 +350,69 @@ struct Question {
     meta_data: String,
 }
 
+/// Problems list response
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Problems {
+    #[allow(dead_code)]
     user_name: String,
+    #[allow(dead_code)]
     num_solved: u32,
+    #[allow(dead_code)]
     num_total: u32,
+    #[allow(dead_code)]
     ac_easy: u32,
+    #[allow(dead_code)]
     ac_medium: u32,
+    #[allow(dead_code)]
     ac_hard: u32,
     pub stat_status_pairs: Vec<StatWithStatus>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Problem status with metadata
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StatWithStatus {
     pub stat: Stat,
-    difficulty: Difficulty,
-    paid_only: bool,
+    pub difficulty: Difficulty,
+    pub paid_only: bool,
+    #[allow(dead_code)]
     is_favor: bool,
+    #[allow(dead_code)]
     frequency: u32,
+    #[allow(dead_code)]
     progress: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Problem statistics
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Stat {
+    #[allow(dead_code)]
     question_id: u32,
     #[serde(rename = "question__article__slug")]
+    #[allow(dead_code)]
     question_article_slug: Option<String>,
     #[serde(rename = "question__title")]
-    question_title: Option<String>,
+    pub question_title: Option<String>,
     #[serde(rename = "question__title_slug")]
-    question_title_slug: Option<String>,
+    pub question_title_slug: Option<String>,
     #[serde(rename = "question__hide")]
+    #[allow(dead_code)]
     question_hide: bool,
+    #[allow(dead_code)]
     total_acs: u32,
+    #[allow(dead_code)]
     total_submitted: u32,
     pub frontend_question_id: u32,
+    #[allow(dead_code)]
     is_new_question: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct Difficulty {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Difficulty {
     level: u32,
 }
 
 impl Display for Difficulty {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.level {
             1 => f.write_str("Easy"),
             2 => f.write_str("Medium"),
@@ -474,5 +558,14 @@ mod tests {
                 std::env::set_var("LEETCODE_COOKIE", cookie);
             }
         }
+    }
+
+    #[test]
+    fn test_leetcode_error_display() {
+        let err = LeetCodeError::ProblemNotFound(42);
+        assert!(err.to_string().contains("Problem #42 not found"));
+
+        let err = LeetCodeError::NoRustVersion(42);
+        assert!(err.to_string().contains("Problem #42 has no Rust version"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,223 +1,422 @@
+//! LeetCode Rust CLI - Generate solution templates from LeetCode
+//!
+//! Usage: leetcode-rust [COMMAND]
+//!
+//! Commands:
+//!   get      Get a specific problem by ID
+//!   random   Get a random problem
+//!   all      Initialize all problems (warning: fetches all problems!)
+//!   solve    Move a problem from problem/ to solution/
+//!   list     List all initialized problems
+//!   help     Print this message or the help of the given subcommand(s)
+//!
+//! Options:
+//!   -h, --help     Print help
+//!   -V, --version  Print version
+
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 extern crate dotenv;
 
+mod error;
 mod fetcher;
 
 use std::{
     fs,
     fs::File,
-    io,
     io::{BufRead, Write},
     path::Path,
     sync::{Arc, Mutex},
 };
 
+use clap::{Parser, Subcommand};
 use dotenv::dotenv;
 use futures::{
     executor::{ThreadPool, block_on},
     future::join_all,
     task::SpawnExt,
 };
+use indicatif::{ProgressBar, ProgressStyle};
 use regex::Regex;
 
-use crate::fetcher::{CodeDefinition, Problem};
+use crate::{
+    error::{LeetCodeError, Result},
+    fetcher::{CodeDefinition, Problem},
+};
 
-/// main() helps to generate the submission template .rs
+/// LeetCode Rust CLI - Generate solution templates from LeetCode
+#[derive(Parser)]
+#[command(name = "leetcode-rust")]
+#[command(about = "Generate LeetCode solution templates in Rust")]
+#[command(version = "0.2.0")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Get a specific problem by ID
+    Get {
+        /// Problem ID to fetch
+        id: u32,
+    },
+    /// Get a random problem
+    Random,
+    /// Initialize all problems (warning: fetches all problems!)
+    All,
+    /// Move a problem from problem/ to solution/
+    Solve {
+        /// Problem ID to solve
+        id: u32,
+    },
+    /// List all initialized problems
+    List,
+}
+
 fn main() {
-    println!("Welcome to leetcode-rust system.\n");
-    dotenv().unwrap();
+    println!("🦀 Welcome to leetcode-rust CLI\n");
 
-    let mut initialized_ids = get_initialized_ids("./src/problem/mod.rs");
-    let random_pattern = Regex::new(r"^random$").unwrap();
-    let solving_pattern = Regex::new(r"^solve (\d+)$").unwrap();
-    let all_pattern = Regex::new(r"^all$").unwrap();
-
-    loop {
-        println!(
-            "Please enter a frontend problem id, \n\
-            or \"random\" to generate a random one, \n\
-            or \"solve $i\" to move problem to solution/, \n\
-            or \"all\" to initialize all problems \n"
-        );
-        let mut _is_random = false;
-        let mut _is_solving = false;
-        let mut _id: u32 = 0;
-        let mut id_arg = String::new();
-        let n = io::stdin()
-            .read_line(&mut id_arg)
-            .expect("Failed to read line");
-        // EOF: exit the interactive loop
-        if n == 0 {
-            break;
-        }
-        let id_arg = id_arg.trim();
-        if id_arg.is_empty() {
-            // empty input: prompt again
-            continue;
-        }
-
-        if random_pattern.is_match(id_arg) {
-            println!("You select random mode.");
-            _id = generate_random_id(&initialized_ids);
-            _is_random = true;
-            println!("Generate random problem: {}", &_id);
-        } else if solving_pattern.is_match(id_arg) {
-            // solve a problem
-            // move it from problem/ to solution/
-            _is_solving = true;
-            _id = solving_pattern
-                .captures(id_arg)
-                .unwrap()
-                .get(1)
-                .unwrap()
-                .as_str()
-                .parse()
-                .unwrap();
-            deal_solving(&_id);
-            break;
-        } else if all_pattern.is_match(id_arg) {
-            // deal all problems
-            let pool = ThreadPool::new().unwrap();
-            let mut tasks = vec![];
-            let problems = match fetcher::get_problems() {
-                Some(p) => p,
-                None => {
-                    println!("Failed to fetch problems list, aborting 'all' operation");
-                    break;
-                }
-            };
-            let mod_file_addon = Arc::new(Mutex::new(vec![]));
-            for problem_stat in problems.stat_status_pairs {
-                if initialized_ids.contains(&problem_stat.stat.frontend_question_id) {
-                    continue;
-                }
-                let mod_file_addon = mod_file_addon.clone();
-                tasks.push(
-                    pool.spawn_with_handle(async move {
-                        let problem = fetcher::get_problem_async(problem_stat).await;
-                        if problem.is_none() {
-                            return;
-                        }
-                        let problem = problem.unwrap();
-                        let code = problem.code_definition.iter().find(|&d| d.value == *"rust");
-                        if code.is_none() {
-                            println!("Problem {} has no rust version.", problem.question_id);
-                            return;
-                        }
-                        // not sure this can be async
-                        async {
-                            mod_file_addon.lock().unwrap().push(format!(
-                                "mod p{:04}_{};",
-                                problem.question_id,
-                                problem.title_slug.replace('-', "_")
-                            ));
-                        }
-                        .await;
-                        let code = code.unwrap();
-                        // not sure this can be async
-                        // maybe should use async-std io
-                        async { deal_problem(&problem, code, false) }.await
-                    })
-                    .unwrap(),
-                );
-            }
-            block_on(join_all(tasks));
-            let mut lib_file = fs::OpenOptions::new()
-                .append(true)
-                .open("./src/problem/mod.rs")
-                .unwrap();
-            let _ = writeln!(lib_file, "{}", mod_file_addon.lock().unwrap().join("\n"));
-            break;
-        } else {
-            _id = match id_arg.parse::<u32>() {
-                Ok(v) => v,
-                Err(_) => {
-                    println!("not a number: {}", id_arg);
-                    continue;
-                }
-            };
-            if initialized_ids.contains(&_id) {
-                println!("The problem you chose has been initialized in problem/");
-                continue;
-            }
-        }
-
-        let problem = match fetcher::get_problem(_id) {
-            Some(p) => p,
-            None => {
-                println!(
-                    "Error: failed to get problem #{_id} (The problem may be paid-only or may not exist)."
-                );
-                continue;
-            }
-        };
-        let code = problem.code_definition.iter().find(|&d| d.value == *"rust");
-        if code.is_none() {
-            println!("Problem {} has no rust version.", &_id);
-            initialized_ids.push(problem.question_id);
-            continue;
-        }
-        let code = code.unwrap();
-        deal_problem(&problem, code, true);
-        break;
+    // Load environment variables
+    if let Err(e) = dotenv() {
+        eprintln!("⚠️  Warning: Failed to load .env file: {}", e);
     }
-    println!("Done, Thanks for using leetcode-rust system.\n");
+
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Commands::Get { id } => handle_get(id),
+        Commands::Random => handle_random(),
+        Commands::All => handle_all(),
+        Commands::Solve { id } => handle_solve(id),
+        Commands::List => handle_list(),
+    };
+
+    match result {
+        Ok(()) => {
+            println!("\n✅ Done! Thanks for using leetcode-rust CLI.\n");
+        }
+        Err(e) => {
+            eprintln!("\n❌ Error: {}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
-fn generate_random_id(except_ids: &[u32]) -> u32 {
+/// Handle the `get` command - fetch a specific problem
+fn handle_get(id: u32) -> Result<()> {
+    let initialized_ids = get_initialized_ids("./src/problem/mod.rs")?;
+
+    if initialized_ids.contains(&id) {
+        return Err(LeetCodeError::AlreadyInitialized(id));
+    }
+
+    let problem = fetcher::get_problem(id)?;
+    let code = find_rust_code(&problem)?;
+
+    deal_problem(&problem, &code, true)?;
+
+    println!(
+        "✅ Successfully created problem #{}: {} [{}]",
+        problem.question_id, problem.title, problem.difficulty
+    );
+
+    Ok(())
+}
+
+/// Handle the `random` command - fetch a random problem
+fn handle_random() -> Result<()> {
+    let initialized_ids = get_initialized_ids("./src/problem/mod.rs")?;
+
+    println!("🎲 Finding a random problem...");
+
+    let problems = fetcher::get_problems()?;
+    let available_problems: Vec<_> = problems
+        .stat_status_pairs
+        .iter()
+        .filter(|p| !p.paid_only && !initialized_ids.contains(&p.stat.frontend_question_id))
+        .collect();
+
+    if available_problems.is_empty() {
+        return Err(LeetCodeError::InvalidInput(
+            "No available problems found".to_string(),
+        ));
+    }
+
     use rand::Rng;
-
     let mut rng = rand::rng();
-    loop {
-        let res: u32 = rng.random_range(1..1106);
-        if !except_ids.contains(&res) {
-            return res;
-        }
-        println!(
-            "Generate a random num ({res}), but it is invalid (the problem may have been solved \
-             or may have no rust version). Regenerate.."
-        );
-    }
+    let selected = available_problems[rng.random_range(0..available_problems.len())];
+    let id = selected.stat.frontend_question_id;
+
+    println!("🎲 Selected random problem: #{}\n", id);
+
+    let problem = fetcher::get_problem(id)?;
+    let code = find_rust_code(&problem)?;
+
+    deal_problem(&problem, &code, true)?;
+
+    println!(
+        "✅ Successfully created problem #{}: {} [{}]",
+        problem.question_id, problem.title, problem.difficulty
+    );
+
+    Ok(())
 }
 
-fn get_initialized_ids(path: &str) -> Vec<u32> {
-    let content = fs::read_to_string(path).unwrap();
-    let id_pattern = Regex::new(r"p(\d{4})_").unwrap();
+/// Handle the `all` command - fetch all problems
+fn handle_all() -> Result<()> {
+    println!("⚠️  Warning: This will fetch ALL LeetCode problems.");
+    println!("   This may take a while and make many API requests.\n");
+
+    let initialized_ids = get_initialized_ids("./src/problem/mod.rs")?;
+    let problems = fetcher::get_problems()?;
+
+    let to_fetch: Vec<_> = problems
+        .stat_status_pairs
+        .into_iter()
+        .filter(|p| !p.paid_only && !initialized_ids.contains(&p.stat.frontend_question_id))
+        .collect();
+
+    let total = to_fetch.len();
+    println!("📊 Found {} problems to fetch\n", total);
+
+    if total == 0 {
+        println!("✅ All problems are already initialized!");
+        return Ok(());
+    }
+
+    // Create progress bar
+    let pb = ProgressBar::new(total as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    let pool = ThreadPool::new().map_err(|e| LeetCodeError::AsyncRuntime(e.to_string()))?;
+
+    let mod_file_addon = Arc::new(Mutex::new(Vec::new()));
+    let pb = Arc::new(Mutex::new(pb));
+
+    let mut tasks = vec![];
+
+    for problem_stat in to_fetch {
+        let mod_file_addon = mod_file_addon.clone();
+        let pb = pb.clone();
+
+        let task = pool
+            .spawn_with_handle(async move {
+                let id = problem_stat.stat.frontend_question_id;
+
+                match fetcher::get_problem_async(problem_stat.clone()).await {
+                    Ok(problem) => {
+                        match find_rust_code(&problem) {
+                            Ok(code) => {
+                                // Generate module line
+                                let file_name = format!(
+                                    "p{:04}_{}",
+                                    problem.question_id,
+                                    problem.title_slug.replace('-', "_")
+                                );
+                                mod_file_addon
+                                    .lock()
+                                    .unwrap()
+                                    .push(format!("pub mod {file_name};"));
+
+                                // Write problem file (async block for consistency)
+                                let result = async { deal_problem(&problem, &code, false) }.await;
+
+                                if let Err(e) = result {
+                                    eprintln!("\n⚠️  Failed to write problem #{}: {}", id, e);
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("\n⚠️  Problem #{} has no Rust version: {}", id, e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("\n⚠️  Failed to fetch problem #{}: {}", id, e);
+                    }
+                }
+
+                pb.lock().unwrap().inc(1);
+            })
+            .map_err(|e| LeetCodeError::AsyncRuntime(e.to_string()))?;
+
+        tasks.push(task);
+    }
+
+    block_on(join_all(tasks));
+
+    pb.lock()
+        .unwrap()
+        .finish_with_message("Done fetching problems");
+
+    // Write all module declarations at once
+    let mut lib_file = fs::OpenOptions::new()
+        .append(true)
+        .open("./src/problem/mod.rs")
+        .map_err(|e| LeetCodeError::file_operation("open", "./src/problem/mod.rs", e))?;
+
+    let declarations = mod_file_addon.lock().unwrap().join("\n");
+    if !declarations.is_empty() {
+        writeln!(lib_file, "\n{}", declarations)
+            .map_err(|e| LeetCodeError::file_operation("write", "./src/problem/mod.rs", e))?;
+    }
+
+    println!("\n✅ Finished fetching all problems!");
+
+    Ok(())
+}
+
+/// Handle the `solve` command - move problem to solution/
+fn handle_solve(id: u32) -> Result<()> {
+    println!("📝 Moving problem #{} to solution/...", id);
+
+    let problem = fetcher::get_problem(id)?;
+
+    let file_name = format!(
+        "p{:04}_{}",
+        problem.question_id,
+        problem.title_slug.replace('-', "_")
+    );
+    let file_path = Path::new("./src/problem").join(format!("{file_name}.rs"));
+
+    // Check problem/ existence
+    if !file_path.exists() {
+        return Err(LeetCodeError::ProblemNotExist(id));
+    }
+
+    // Check solution/ no existence
+    let solution_name = format!(
+        "s{:04}_{}",
+        problem.question_id,
+        problem.title_slug.replace('-', "_")
+    );
+    let solution_path = Path::new("./src/solution").join(format!("{solution_name}.rs"));
+
+    if solution_path.exists() {
+        return Err(LeetCodeError::SolutionExists(id));
+    }
+
+    // Rename/move file
+    fs::rename(&file_path, &solution_path)
+        .map_err(|e| LeetCodeError::file_operation("rename", &file_path, e))?;
+
+    // Remove from problem/mod.rs
+    let mod_file = "./src/problem/mod.rs";
+    let target_line = format!("pub mod {file_name};");
+    let lines: Vec<String> = std::io::BufReader::new(
+        File::open(mod_file).map_err(|e| LeetCodeError::file_operation("open", mod_file, e))?,
+    )
+    .lines()
+    .map(|x| x.unwrap())
+    .filter(|x| *x != target_line)
+    .collect();
+
+    fs::write(mod_file, lines.join("\n"))
+        .map_err(|e| LeetCodeError::file_operation("write", mod_file, e))?;
+
+    // Insert into solution/mod.rs
+    let mut lib_file = fs::OpenOptions::new()
+        .append(true)
+        .open("./src/solution/mod.rs")
+        .map_err(|e| LeetCodeError::file_operation("open", "./src/solution/mod.rs", e))?;
+
+    writeln!(lib_file, "pub mod {solution_name};")
+        .map_err(|e| LeetCodeError::file_operation("write", "./src/solution/mod.rs", e))?;
+
+    println!("✅ Successfully moved problem #{} to solution/", id);
+
+    Ok(())
+}
+
+/// Handle the `list` command - list initialized problems
+fn handle_list() -> Result<()> {
+    let initialized_ids = get_initialized_ids("./src/problem/mod.rs")?;
+
+    if initialized_ids.is_empty() {
+        println!("No problems initialized yet.");
+        println!("\nUse one of the following commands to get started:");
+        println!("  leetcode-rust get <id>    - Get a specific problem");
+        println!("  leetcode-rust random      - Get a random problem");
+        return Ok(());
+    }
+
+    println!(
+        "📚 Initialized problems ({} total):\n",
+        initialized_ids.len()
+    );
+
+    // Group by hundreds for better readability
+    let mut ids = initialized_ids;
+    ids.sort_unstable();
+
+    for chunk in ids.chunks(10) {
+        let ids_str: Vec<String> = chunk.iter().map(|id| format!("#{}", id)).collect();
+        println!("  {}", ids_str.join(", "));
+    }
+
+    Ok(())
+}
+
+/// Find Rust code definition in a problem
+fn find_rust_code(problem: &Problem) -> Result<CodeDefinition> {
+    problem
+        .code_definition
+        .iter()
+        .find(|d| d.value == "rust")
+        .cloned()
+        .ok_or(LeetCodeError::NoRustVersion(problem.question_id))
+}
+
+/// Get list of already initialized problem IDs
+fn get_initialized_ids(path: &str) -> Result<Vec<u32>> {
+    let content =
+        fs::read_to_string(path).map_err(|e| LeetCodeError::file_operation("read", path, e))?;
+    let id_pattern = Regex::new(r"p(\d{4})_")?;
 
     let mut ret = vec![];
-    for l in content.lines() {
-        if !l.trim().starts_with("//")
-            && let Some(id) = id_pattern.captures(l)
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("//")
+            && let Some(id) = id_pattern.captures(trimmed)
+            && let Ok(id_num) = id.get(1).unwrap().as_str().parse::<u32>()
         {
-            ret.push(id.get(1).unwrap().as_str().parse::<u32>().unwrap());
+            ret.push(id_num);
         }
     }
 
-    ret
+    Ok(ret)
 }
 
+/// Parse extra use statements based on code content
 fn parse_extra_use(code: &str) -> String {
     let mut extra_use_line = String::new();
-    // a linked-list problem
     if code.contains("pub struct ListNode") {
-        extra_use_line.push_str("\nuse crate::util::linked_list::{ListNode, to_list};")
+        extra_use_line.push_str("\nuse crate::util::linked_list::{ListNode, to_list};");
     }
     if code.contains("pub struct TreeNode") {
-        extra_use_line.push_str("\nuse crate::util::tree::{TreeNode, to_tree};")
+        extra_use_line.push_str("\nuse crate::util::tree::{TreeNode, to_tree};");
     }
     if code.contains("pub struct Point") {
-        extra_use_line.push_str("\nuse crate::util::point::Point;")
+        extra_use_line.push_str("\nuse crate::util::point::Point;");
     }
     extra_use_line
 }
 
+/// Build problem link
 fn parse_problem_link(problem: &Problem) -> String {
     format!("https://leetcode.com/problems/{}/", problem.title_slug)
 }
 
+/// Build discuss link
 fn parse_discuss_link(problem: &Problem) -> String {
     format!(
         "https://leetcode.com/problems/{}/discuss/?currentPage=1&orderBy=most_votes&query=",
@@ -225,8 +424,9 @@ fn parse_discuss_link(problem: &Problem) -> String {
     )
 }
 
+/// Insert default return value in code template
 fn insert_return_in_code(return_type: &str, code: &str) -> String {
-    let re = Regex::new(r"\{[ \n]+}").unwrap();
+    let re = Regex::new(r"\{\s*}").unwrap();
     match return_type {
         "ListNode" => re
             .replace(code, "{\n        Some(Box::new(ListNode::new(0)))\n    }")
@@ -244,7 +444,6 @@ fn insert_return_in_code(return_type: &str, code: &str) -> String {
         "double" => re.replace(code, "{\n        0f64\n    }").to_string(),
         "double[]" => re.replace(code, "{\n        vec![]\n    }").to_string(),
         "int[]" => re.replace(code, "{\n        vec![]\n    }").to_string(),
-
         "integer" => re.replace(code, "{\n        0\n    }").to_string(),
         "integer[]" => re.replace(code, "{\n        vec![]\n    }").to_string(),
         "integer[][]" => re.replace(code, "{\n        vec![]\n    }").to_string(),
@@ -268,8 +467,8 @@ fn insert_return_in_code(return_type: &str, code: &str) -> String {
     }
 }
 
+/// Clean HTML content for Rust comments
 fn build_desc(content: &str) -> String {
-    // TODO: fix this shit
     content
         .replace("<strong>", "")
         .replace("</strong>", "")
@@ -303,55 +502,18 @@ fn build_desc(content: &str) -> String {
         .replace('\n', "\n * ")
 }
 
-fn deal_solving(id: &u32) {
-    let problem = fetcher::get_problem(*id).unwrap();
+/// Generate problem file from template
+fn deal_problem(problem: &Problem, code: &CodeDefinition, write_mod_file: bool) -> Result<()> {
     let file_name = format!(
         "p{:04}_{}",
         problem.question_id,
         problem.title_slug.replace('-', "_")
     );
     let file_path = Path::new("./src/problem").join(format!("{file_name}.rs"));
-    // check problem/ existence
-    if !file_path.exists() {
-        panic!("problem does not exist");
-    }
-    // check solution/ no existence
-    let solution_name = format!(
-        "s{:04}_{}",
-        problem.question_id,
-        problem.title_slug.replace('-', "_")
-    );
-    let solution_path = Path::new("./src/solution").join(format!("{solution_name}.rs"));
-    if solution_path.exists() {
-        panic!("solution exists");
-    }
-    // rename/move file
-    fs::rename(file_path, solution_path).unwrap();
-    // remove from problem/mod.rs
-    let mod_file = "./src/problem/mod.rs";
-    let target_line = format!("mod {file_name};");
-    let lines: Vec<String> = io::BufReader::new(File::open(mod_file).unwrap())
-        .lines()
-        .map(|x| x.unwrap())
-        .filter(|x| *x != target_line)
-        .collect();
-    let _ = fs::write(mod_file, lines.join("\n"));
-    // insert into solution/mod.rs
-    let mut lib_file = fs::OpenOptions::new()
-        .append(true)
-        .open("./src/solution/mod.rs")
-        .unwrap();
-    let _ = writeln!(lib_file, "mod {solution_name};");
-}
 
-fn deal_problem(problem: &Problem, code: &CodeDefinition, write_mod_file: bool) {
-    let file_name = format!(
-        "p{:04}_{}",
-        problem.question_id,
-        problem.title_slug.replace('-', "_")
-    );
-    let file_path = Path::new("./src/problem").join(format!("{file_name}.rs"));
-    let template = fs::read_to_string("./template.rs").unwrap();
+    let template = fs::read_to_string("./template.rs")
+        .map_err(|e| LeetCodeError::Template(format!("Failed to read template.rs: {}", e)))?;
+
     let source = template
         .replace("__PROBLEM_TITLE__", &problem.title)
         .replace("__PROBLEM_DESC__", &build_desc(&problem.content))
@@ -368,19 +530,25 @@ fn deal_problem(problem: &Problem, code: &CodeDefinition, write_mod_file: bool) 
         .write(true)
         .create(true)
         .truncate(true)
-        .open(file_path)
-        .unwrap();
+        .open(&file_path)
+        .map_err(|e| LeetCodeError::file_operation("create", &file_path, e))?;
 
-    file.write_all(source.as_bytes()).unwrap();
+    file.write_all(source.as_bytes())
+        .map_err(|e| LeetCodeError::file_operation("write", &file_path, e))?;
+
     drop(file);
 
     if write_mod_file {
         let mut lib_file = fs::OpenOptions::new()
             .append(true)
             .open("./src/problem/mod.rs")
-            .unwrap();
-        let _ = writeln!(lib_file, "pub mod {file_name};");
+            .map_err(|e| LeetCodeError::file_operation("open", "./src/problem/mod.rs", e))?;
+
+        writeln!(lib_file, "pub mod {file_name};")
+            .map_err(|e| LeetCodeError::file_operation("write", "./src/problem/mod.rs", e))?;
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -397,10 +565,48 @@ mod test {
         pub mod p0002_add_two_numbers;
         pub mod p0003_longest_substring_without_repeating_characters;"#;
         writeln!(file, "{content}").unwrap();
-        let ids = get_initialized_ids(path.to_str().unwrap());
+        let ids = get_initialized_ids(path.to_str().unwrap()).unwrap();
         println!("{ids:?}");
         assert!(ids.len() == 2);
         assert!(ids[0] == 2);
         assert!(ids[1] == 3);
+    }
+
+    #[test]
+    fn test_parse_extra_use() {
+        let code_with_listnode = "pub struct ListNode";
+        assert!(parse_extra_use(code_with_listnode).contains("linked_list"));
+
+        let code_with_treenode = "pub struct TreeNode";
+        assert!(parse_extra_use(code_with_treenode).contains("tree"));
+
+        let code_with_point = "pub struct Point";
+        assert!(parse_extra_use(code_with_point).contains("point"));
+
+        let code_empty = "struct Solution;";
+        assert!(parse_extra_use(code_empty).is_empty());
+    }
+
+    #[test]
+    fn test_insert_return_in_code() {
+        let code = "impl Solution { pub fn test() {} }";
+        let result = insert_return_in_code("integer", code);
+        assert!(result.contains("0"));
+
+        let result = insert_return_in_code("string", code);
+        assert!(result.contains("String::new()"));
+
+        let result = insert_return_in_code("int[]", code);
+        assert!(result.contains("vec![]"));
+    }
+
+    #[test]
+    fn test_build_desc() {
+        let html = "<p>Hello <strong>world</strong></p>";
+        let result = build_desc(html);
+        assert!(!result.contains("<p>"));
+        assert!(!result.contains("<strong>"));
+        assert!(result.contains("Hello"));
+        assert!(result.contains("world"));
     }
 }


### PR DESCRIPTION
## Summary

Refactor the CLI to address all issues in #5:
- User-friendly errors instead of panics
- CLI arguments with subcommands instead of interactive mode
- Progress indicators for long-running operations
- Retry logic for unstable network connections

## Changes

### Dependencies
- Add `clap` for CLI argument parsing with derive macros
- Add `thiserror` for structured error handling
- Add `indicatif` for progress bars
- Add `tokio` for async retry delays

### New Features
- **Structured errors** (src/error.rs): Replace panics with LeetCodeError enum
- **Retry logic**: Exponential backoff (3 retries, 500ms initial delay)
- **CLI subcommands**:
  - `leetcode-rust get <id>` - Get specific problem
  - `leetcode-rust random` - Get random problem
  - `leetcode-rust all` - Fetch all problems with progress bar
  - `leetcode-rust solve <id>` - Move to solution/
  - `leetcode-rust list` - List initialized problems

### Improvements
- User-friendly error messages (no more panics!)
- Progress indicators during API calls and batch operations
- Proper exit codes for scripting
- Better network resilience with automatic retries

### Documentation
- Update README.md with new CLI syntax
- Update AGENTS.md with error handling docs

## Verification

- ✅ All 101 tests pass
- ✅ All checks pass (fmt, clippy, machete, typos)
- ✅ Manual testing of CLI commands

Closes #5
