### PR TITLE
test: add comprehensive unit tests for CLI refactor

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -114,3 +114,155 @@ impl LeetCodeError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_problem_not_found_error() {
+        let err = LeetCodeError::ProblemNotFound(42);
+        let msg = err.to_string();
+        assert!(msg.contains("Problem #42 not found"));
+        assert!(msg.contains("paid-only"));
+    }
+
+    #[test]
+    fn test_no_rust_version_error() {
+        let err = LeetCodeError::NoRustVersion(100);
+        assert!(err.to_string().contains("Problem #100 has no Rust version"));
+    }
+
+    #[test]
+    fn test_already_initialized_error() {
+        let err = LeetCodeError::AlreadyInitialized(1);
+        assert!(
+            err.to_string()
+                .contains("Problem #1 has already been initialized")
+        );
+    }
+
+    #[test]
+    fn test_solution_exists_error() {
+        let err = LeetCodeError::SolutionExists(5);
+        assert!(
+            err.to_string()
+                .contains("Solution for problem #5 already exists")
+        );
+    }
+
+    #[test]
+    fn test_problem_not_exist_error() {
+        let err = LeetCodeError::ProblemNotExist(10);
+        assert!(
+            err.to_string()
+                .contains("Problem file for #10 doesn't exist")
+        );
+    }
+
+    #[test]
+    fn test_http_error() {
+        let err = LeetCodeError::Http("connection refused".to_string());
+        assert!(
+            err.to_string()
+                .contains("HTTP request failed: connection refused")
+        );
+    }
+
+    #[test]
+    fn test_http_client_build_error() {
+        let err = LeetCodeError::HttpClientBuild("tls error".to_string());
+        assert!(
+            err.to_string()
+                .contains("Failed to build HTTP client: tls error")
+        );
+    }
+
+    #[test]
+    fn test_invalid_input_error() {
+        let err = LeetCodeError::InvalidInput("bad input".to_string());
+        assert!(err.to_string().contains("Invalid input: bad input"));
+    }
+
+    #[test]
+    fn test_template_error() {
+        let err = LeetCodeError::Template("missing file".to_string());
+        assert!(
+            err.to_string()
+                .contains("Template file error: missing file")
+        );
+    }
+
+    #[test]
+    fn test_async_runtime_error() {
+        let err = LeetCodeError::AsyncRuntime("pool failed".to_string());
+        assert!(err.to_string().contains("Async runtime error: pool failed"));
+    }
+
+    #[test]
+    fn test_missing_title_slug_error() {
+        let err = LeetCodeError::MissingTitleSlug(99);
+        assert!(err.to_string().contains("Problem #99 has no title slug"));
+    }
+
+    #[test]
+    fn test_metadata_parse_error() {
+        let err = LeetCodeError::MetadataParse("invalid json".to_string());
+        assert!(
+            err.to_string()
+                .contains("Failed to parse metadata: invalid json")
+        );
+    }
+
+    #[test]
+    fn test_code_definition_parse_error() {
+        let err = LeetCodeError::CodeDefinitionParse("missing field".to_string());
+        assert!(
+            err.to_string()
+                .contains("Failed to parse code definition: missing field")
+        );
+    }
+
+    #[test]
+    fn test_retry_exhausted_error() {
+        let err = LeetCodeError::retry_exhausted(3, "timeout");
+        let msg = err.to_string();
+        assert!(msg.contains("Network error after 3 retries"));
+        assert!(msg.contains("timeout"));
+    }
+
+    #[test]
+    fn test_file_operation_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err = LeetCodeError::file_operation("read", "/tmp/test.rs", io_err);
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to read file at /tmp/test.rs"));
+        assert!(msg.contains("file not found"));
+    }
+
+    #[test]
+    fn test_from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "no access");
+        let err: LeetCodeError = io_err.into();
+        assert!(err.to_string().contains("IO error: no access"));
+    }
+
+    #[test]
+    fn test_from_regex_error() {
+        // Create an invalid regex pattern to trigger an error
+        // Using \x{0} which creates an invalid regex error at compile time in some cases,
+        // but here we construct it dynamically to avoid compile-time errors
+        let pattern = "a{2,1}";
+        let regex_err = regex::Regex::new(pattern).unwrap_err();
+        let err: LeetCodeError = regex_err.into();
+        assert!(err.to_string().contains("Regex error"));
+    }
+
+    #[test]
+    fn test_result_type_alias() {
+        fn might_fail() -> Result<i32> {
+            Ok(42)
+        }
+        assert_eq!(might_fail().unwrap(), 42);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,4 +609,143 @@ mod test {
         assert!(result.contains("Hello"));
         assert!(result.contains("world"));
     }
+
+    #[test]
+    fn test_insert_return_in_code_all_types() {
+        let code = "impl Solution { pub fn test() {} }";
+
+        // Test integer
+        let result = insert_return_in_code("integer", code);
+        assert!(result.contains("0"));
+
+        // Test boolean
+        let result = insert_return_in_code("boolean", code);
+        assert!(result.contains("false"));
+
+        // Test character
+        let result = insert_return_in_code("character", code);
+        assert!(result.contains("'0'"));
+
+        // Test double
+        let result = insert_return_in_code("double", code);
+        assert!(result.contains("0f64"));
+
+        // Test ListNode
+        let result = insert_return_in_code("ListNode", code);
+        assert!(result.contains("ListNode::new(0)"));
+
+        // Test TreeNode
+        let result = insert_return_in_code("TreeNode", code);
+        assert!(result.contains("TreeNode::new(0)"));
+
+        // Test null/void (should return code unchanged)
+        let result = insert_return_in_code("null", code);
+        assert_eq!(result, code);
+        let result = insert_return_in_code("void", code);
+        assert_eq!(result, code);
+
+        // Test unknown type (should return code unchanged)
+        let result = insert_return_in_code("unknown_type", code);
+        assert_eq!(result, code);
+    }
+
+    #[test]
+    fn test_insert_return_in_code_array_types() {
+        let code = "impl Solution { pub fn test() {} }";
+
+        // All array types should return vec![]
+        let array_types = vec![
+            "int[]",
+            "integer[]",
+            "integer[][]",
+            "double[]",
+            "string[]",
+            "character[][]",
+            "ListNode[]",
+            "list<String>",
+            "list<TreeNode>",
+            "list<boolean>",
+            "list<double>",
+            "list<integer>",
+            "list<list<integer>>",
+            "list<list<string>>",
+            "list<string>",
+        ];
+
+        for ty in array_types {
+            let result = insert_return_in_code(ty, code);
+            assert!(
+                result.contains("vec![]"),
+                "Type {} should return vec![]",
+                ty
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_desc_html_entities() {
+        // Test HTML entity replacements
+        let html = "&gt; &lt; &quot; &minus; &#39; &nbsp;";
+        let result = build_desc(html);
+        assert!(result.contains(">"));
+        assert!(result.contains("<"));
+        assert!(result.contains("\""));
+        assert!(result.contains("-"));
+        assert!(result.contains("'"));
+        assert!(result.contains(" "));
+    }
+
+    #[test]
+    fn test_build_desc_sup_sub() {
+        let html = "x<sup>2</sup> and y<sub>i</sub>";
+        let result = build_desc(html);
+        assert!(result.contains("x^2"));
+        assert!(!result.contains("<sup>"));
+        assert!(!result.contains("<sub>"));
+    }
+
+    #[test]
+    fn test_build_desc_lists() {
+        let html = "<ul><li>item1</li><li>item2</li></ul>";
+        let result = build_desc(html);
+        assert!(!result.contains("<ul>"));
+        assert!(!result.contains("</ul>"));
+        assert!(!result.contains("<li>"));
+        assert!(!result.contains("</li>"));
+        assert!(result.contains("item1"));
+        assert!(result.contains("item2"));
+    }
+
+    #[test]
+    fn test_parse_problem_link() {
+        let problem = Problem {
+            title: "Two Sum".to_string(),
+            title_slug: "two-sum".to_string(),
+            content: "".to_string(),
+            code_definition: vec![],
+            sample_test_case: "".to_string(),
+            difficulty: "Easy".to_string(),
+            question_id: 1,
+            return_type: "integer[]".to_string(),
+        };
+        let link = parse_problem_link(&problem);
+        assert_eq!(link, "https://leetcode.com/problems/two-sum/");
+    }
+
+    #[test]
+    fn test_parse_discuss_link() {
+        let problem = Problem {
+            title: "Two Sum".to_string(),
+            title_slug: "two-sum".to_string(),
+            content: "".to_string(),
+            code_definition: vec![],
+            sample_test_case: "".to_string(),
+            difficulty: "Easy".to_string(),
+            question_id: 1,
+            return_type: "integer[]".to_string(),
+        };
+        let link = parse_discuss_link(&problem);
+        assert!(link.contains("leetcode.com/problems/two-sum/discuss/"));
+        assert!(link.contains("orderBy=most_votes"));
+    }
 }


### PR DESCRIPTION
## Summary

Add comprehensive unit tests to improve coverage for the CLI refactor (follow-up to #298).

## Changes

### error.rs (18 new tests)
- Test all error variants display messages
- Test error helper methods (file_operation, retry_exhausted)
- Test From trait implementations (io::Error, regex::Error)

### main.rs (7 new tests)
- Test all return type mappings in insert_return_in_code
- Test array type mappings (int[], integer[][], etc.)
- Test HTML entity/element stripping in build_desc
- Test parse_problem_link and parse_discuss_link

## Verification

- ✅ All 126 tests pass
- ✅ All checks pass (fmt, clippy, machete, typos)

This improves patch coverage for the CLI refactor changes.