### PR TITLE
config: add do-not-merge label condition to Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,7 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
         - -conflict
+        - label != do-not-merge
         - check-success=fmt
         - check-success=clippy
         - check-success=typos


### PR DESCRIPTION
Add `label != do-not-merge` condition to Mergify config to allow preventing auto-merge by adding a label.