### PR TITLE
test: verify do-not-merge label prevents auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ cargo nextest run
 2. Run `cargo run -- get 1` to fetch problem #1
 3. Implement your solution in the generated file
 4. Run `cargo test test_1` to verify
+# Mergify label test


### PR DESCRIPTION
## Test PR

This is a test to verify that the `do-not-merge` label correctly prevents Mergify from auto-merging.

## Expected Behavior
- All checks should pass
- Mergify should NOT auto-merge this PR because it has the `do-not-merge` label
- Manual merge should still be possible

## Cleanup
- [ ] Close this PR after verifying the label works
- [ ] Do not merge to master

cc @ben1009